### PR TITLE
Compress stairs in homedecor's building_blocks mod

### DIFF
--- a/src/compress.lua
+++ b/src/compress.lua
@@ -262,12 +262,25 @@ local moreblocks_nodes = {
 	"ice",
 }
 
+local building_blocks_nodes = {
+	"grate",
+	"smoothglass",
+	"woodglass",
+	"Adobe",
+	"fakegrass",
+	"hardwood",
+	"Roofing",
+	"Tar",
+	"Marble",
+}
+
 local colors_moreblocks = copy(colors)
 insert(colors_moreblocks, "white")
 
 local moreblocks_mods = {
 	wool = colors_moreblocks,
 	moreblocks = moreblocks_nodes,
+	building_blocks = building_blocks_nodes,
 }
 
 local t = {}


### PR DESCRIPTION
The [Homedecor](https://forum.minetest.net/viewtopic.php?t=2041) modpack includes [stairsplus blocks (stairs, slopes, etc.) for building_blocks](https://github.com/mt-mods/homedecor_modpack/blob/master/building_blocks/node_stairs.lua). Stairs added by moreblocks can be compressed (collapsed), but stairs added by building_blocks cannot. This means these stairs take up ~5 blocks in the inventory.

Homedecor is a relatively common mod, so this pull request was made to compress the stairs it adds, as was done with moreblocks.
