### PR TITLE
Add support for disabling 'trash all' button.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -38,6 +38,8 @@ i3 = {
 
 		damage_enabled = core.settings:get_bool"enable_damage",
 		progressive_mode = core.settings:get_bool"i3_progressive_mode",
+		disable_trash_all = core.settings:get_bool"i3_disable_trash_all",
+
 	},
 
 	categories = {

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,2 +1,6 @@
 # The progressive mode shows recipes you can craft from items you ever had in your inventory.
 i3_progressive_mode    (Learn crafting recipes progressively)    bool false
+
+# Turn off support for the "trash all" button.
+i3_disable_trash_all    (Disable support for trashing all inventory)     bool false
+

--- a/src/gui.lua
+++ b/src/gui.lua
@@ -772,12 +772,15 @@ local function get_inventory_fs(player, data, fs)
 	get_container(fs, data, player, yoffset, ctn_len, award_list, awards_unlocked, award_list_nb, bag_size)
 	fs"scroll_container_end[]"
 
-	local btn = {
-		{"trash",    ES"Clear inventory"},
-		{"sort",     ES"Sort inventory"},
-		{"settings", ES"Settings"},
-		{"home",     ES"Go home"},
-	}
+	local btn = {}
+
+	if not i3.settings.disable_trash_all then
+		insert(btn, {"trash", ES"Clear inventory"})
+	end
+
+	insert(btn, {"sort",     ES"Sort inventory"})
+	insert(btn, {"settings", ES"Settings"})
+	insert(btn, {"home",     ES"Go home"})
 
 	for i, v in ipairs(btn) do
 		local btn_name, tooltip = unpack(v)


### PR DESCRIPTION
I had a player attempt to drag/drop a pile of dirt over to the 'trash-all' button and then trigger the deletion of their inventory. This caused some confusion (despite requiring a confirmation) and despair. To avoid this in the future, I've added this setting to allow for disabling this button.

I am open to changing the name of the variable, etc if this causes further confusion.

Thank you for this wonderful mod, it has been a joy to use.