### PR TITLE
Add setting for default state of legacy_inventory

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -71,6 +71,7 @@ i3 = {
 		font_size = 0,
 		collapse = true,
 		inv_compress = true,
+		legacy_inventory = core.settings:get_bool("i3_legacy_inv_default", false),
 	},
 
 	files = {

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,2 +1,3 @@
 # The progressive mode shows recipes you can craft from items you ever had in your inventory.
 i3_progressive_mode    (Learn crafting recipes progressively)    bool false
+i3_legacy_inv_default  (Use minetest original inventory size)    bool false


### PR DESCRIPTION
Allows the default value of the "Legacy inventory" toggle to be set via settings.